### PR TITLE
package.json: Add "body-parser" to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "axios": "^0.19.0",
+    "body-parser": "^1.19.2",
     "connect-flash": "^0.1.1",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",


### PR DESCRIPTION
`app.js` fails to start without `body-parser` installed. Add `body-parser@1.19.2` to `package.json`.